### PR TITLE
Playing with Riverpod

### DIFF
--- a/lib/model/country.dart
+++ b/lib/model/country.dart
@@ -139,6 +139,19 @@ class Country extends EnumClass {
   static BuiltSet<Country> get values => _$values;
   static Country valueOf(String name) => _$valueOf(name);
   static Serializer<Country> get serializer => _$countrySerializer;
+  static Country? safeValueOf(String name) {
+    if (name.trim().isEmpty) {
+      return null;
+    }
+    try {
+      return valueOf(name);
+    } on ArgumentError catch (e) {
+      if (name.isNotEmpty) {
+        Log.w('Country unknown name: $name', ex: e);
+      }
+      return null;
+    }
+  }
 
   String? localize(BuildContext context) {
     switch (this) {

--- a/lib/ui/base/page_state_plante.dart
+++ b/lib/ui/base/page_state_plante.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 import 'package:plante/logging/analytics.dart';
 import 'package:plante/ui/base/components/visibility_detector_plante.dart';
 
-abstract class PageStatePlante<T extends StatefulWidget> extends State<T> {
+abstract class PagePlante extends ConsumerStatefulWidget {
+  const PagePlante({Key? key}) : super(key: key);
+}
+
+abstract class PageStatePlante<T extends PagePlante> extends ConsumerState<T> {
   late final Analytics _analytics;
   final String _pageName;
 

--- a/lib/ui/crop/image_crop_page.dart
+++ b/lib/ui/crop/image_crop_page.dart
@@ -15,7 +15,7 @@ import 'package:plante/ui/base/page_state_plante.dart';
 import 'package:plante/ui/base/text_styles.dart';
 import 'package:plante/ui/base/ui_utils.dart';
 
-class ImageCropPage extends StatefulWidget {
+class ImageCropPage extends PagePlante {
   final String imagePath;
   final Directory outFolder;
   const ImageCropPage(

--- a/lib/ui/first_screen/external_auth_page.dart
+++ b/lib/ui/first_screen/external_auth_page.dart
@@ -25,7 +25,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 typedef ExternalAuthCallback = Future<bool> Function(UserParams userParams);
 
-class ExternalAuthPage extends StatefulWidget {
+class ExternalAuthPage extends PagePlante {
   const ExternalAuthPage({Key? key}) : super(key: key);
 
   @override

--- a/lib/ui/first_screen/init_user_page.dart
+++ b/lib/ui/first_screen/init_user_page.dart
@@ -24,7 +24,7 @@ import 'package:plante/ui/langs/user_langs_widget.dart';
 typedef UserParamsSpecifiedCallback = Future<bool> Function(
     UserParams userParams);
 
-class InitUserPage extends StatefulWidget {
+class InitUserPage extends PagePlante {
   static const MIN_NAME_LENGTH = 3;
 
   const InitUserPage({Key? key}) : super(key: key);

--- a/lib/ui/langs/user_langs_page.dart
+++ b/lib/ui/langs/user_langs_page.dart
@@ -14,7 +14,7 @@ import 'package:plante/ui/base/text_styles.dart';
 import 'package:plante/ui/base/ui_utils.dart';
 import 'package:plante/ui/langs/user_langs_widget.dart';
 
-class UserLangsPage extends StatefulWidget {
+class UserLangsPage extends PagePlante {
   const UserLangsPage({Key? key}) : super(key: key);
 
   @override

--- a/lib/ui/main/main_page.dart
+++ b/lib/ui/main/main_page.dart
@@ -5,7 +5,7 @@ import 'package:plante/ui/map/map_page/map_page.dart';
 import 'package:plante/ui/scan/barcode_scan_page.dart';
 import 'package:plante/ui/scan/viewed_products_history_page.dart';
 
-class MainPage extends StatefulWidget {
+class MainPage extends PagePlante {
   static const PAGE_NAME = 'MainPage';
   const MainPage({Key? key}) : super(key: key);
 

--- a/lib/ui/map/create_shop_page.dart
+++ b/lib/ui/map/create_shop_page.dart
@@ -16,7 +16,7 @@ import 'package:plante/ui/base/page_state_plante.dart';
 import 'package:plante/ui/base/snack_bar_utils.dart';
 import 'package:plante/ui/base/text_styles.dart';
 
-class CreateShopPage extends StatefulWidget {
+class CreateShopPage extends PagePlante {
   final Coord shopCoord;
   const CreateShopPage({Key? key, required this.shopCoord}) : super(key: key);
   @override

--- a/lib/ui/map/map_page/map_page.dart
+++ b/lib/ui/map/map_page/map_page.dart
@@ -46,7 +46,7 @@ enum MapPageRequestedMode {
   SELECT_SHOPS,
 }
 
-class MapPage extends StatefulWidget {
+class MapPage extends PagePlante {
   final Product? product;
   final List<Shop> initialSelectedShops;
   final MapPageRequestedMode requestedMode;

--- a/lib/ui/map/search_page/map_search_page.dart
+++ b/lib/ui/map/search_page/map_search_page.dart
@@ -33,7 +33,7 @@ import 'package:plante/ui/map/search_page/map_search_page_model.dart';
 import 'package:plante/ui/map/search_page/map_search_page_result.dart';
 import 'package:plante/ui/map/search_page/map_search_result.dart';
 
-class MapSearchPage extends StatefulWidget {
+class MapSearchPage extends PagePlante {
   final MapSearchPageResult? initialState;
   const MapSearchPage({Key? key, this.initialState}) : super(key: key);
 

--- a/lib/ui/product/display_product_page.dart
+++ b/lib/ui/product/display_product_page.dart
@@ -43,7 +43,7 @@ import 'product_header_widget.dart';
 
 typedef ProductUpdatedCallback = void Function(Product updatedProduct);
 
-class DisplayProductPage extends StatefulWidget {
+class DisplayProductPage extends PagePlante {
   final Product _initialProduct;
   final ProductUpdatedCallback? productUpdatedCallback;
 

--- a/lib/ui/product/help_with_veg_status_page.dart
+++ b/lib/ui/product/help_with_veg_status_page.dart
@@ -20,7 +20,7 @@ import 'package:plante/ui/base/ui_utils.dart';
 typedef DoneCallback = void Function();
 typedef ProductUpdatedCallback = void Function(Product updatedProduct);
 
-class HelpWithVegStatusPage extends StatefulWidget {
+class HelpWithVegStatusPage extends PagePlante {
   final Product initialProduct;
   final DoneCallback? doneCallback;
   final ProductUpdatedCallback? productUpdatedCallback;

--- a/lib/ui/product/init_product_page.dart
+++ b/lib/ui/product/init_product_page.dart
@@ -40,7 +40,7 @@ import 'init_product_page_model.dart';
 typedef DoneCallback = void Function();
 typedef ProductUpdatedCallback = void Function(Product updatedProduct);
 
-class InitProductPage extends StatefulWidget {
+class InitProductPage extends PagePlante {
   final Product initialProduct;
   final List<Shop> initialShops;
   final ProductUpdatedCallback? productUpdatedCallback;

--- a/lib/ui/product/product_photo_page.dart
+++ b/lib/ui/product/product_photo_page.dart
@@ -8,7 +8,7 @@ import 'package:plante/ui/base/components/headline_bordered_plante.dart';
 import 'package:plante/ui/base/page_state_plante.dart';
 import 'package:plante/ui/product/_product_images_helper.dart';
 
-class ProductPhotoPage extends StatefulWidget {
+class ProductPhotoPage extends PagePlante {
   final Product product;
   final ProductImageType imageType;
   const ProductPhotoPage(

--- a/lib/ui/scan/barcode_scan_page.dart
+++ b/lib/ui/scan/barcode_scan_page.dart
@@ -33,7 +33,7 @@ import 'package:plante/ui/scan/barcode_scan_page_model.dart';
 import 'package:plante/ui/settings_page.dart';
 import 'package:qr_code_scanner/qr_code_scanner.dart' as qr;
 
-class BarcodeScanPage extends StatefulWidget {
+class BarcodeScanPage extends PagePlante {
   final Shop? addProductToShop;
   final _testingStorage = _TestingStorage();
 

--- a/lib/ui/scan/viewed_products_history_page.dart
+++ b/lib/ui/scan/viewed_products_history_page.dart
@@ -19,7 +19,7 @@ import 'package:plante/ui/base/text_styles.dart';
 import 'package:plante/ui/base/ui_utils.dart';
 import 'package:plante/ui/product/product_page_wrapper.dart';
 
-class ViewedProductsHistoryPage extends StatefulWidget {
+class ViewedProductsHistoryPage extends PagePlante {
   const ViewedProductsHistoryPage({Key? key}) : super(key: key);
 
   @override

--- a/lib/ui/settings_page.dart
+++ b/lib/ui/settings_page.dart
@@ -25,7 +25,7 @@ import 'package:plante/ui/base/ui_utils.dart';
 import 'package:plante/ui/langs/user_langs_page.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class SettingsPage extends StatefulWidget {
+class SettingsPage extends PagePlante {
   @override
   _SettingsPageState createState() => _SettingsPageState();
 }

--- a/lib/ui/shop/shop_product_range_page_model.dart
+++ b/lib/ui/shop/shop_product_range_page_model.dart
@@ -23,12 +23,11 @@ class ShopProductRangePageModel {
 
   late final ConfirmedProductsModel _confirmedProductsModel;
   late final SuggestedProductsModel _suggestedProductsModel;
+  final OffShopsManager _offShopsManager;
 
   final Shop _shop;
   late final FutureShortAddress _address;
   final VoidCallback _updateCallback;
-
-  OffShopsManager offShopsmanager;
 
   UserParams get user => _userParamsController.cachedUserParams!;
   FutureShortAddress get address => _address;
@@ -52,9 +51,9 @@ class ShopProductRangePageModel {
       ProductsObtainer productsObtainer,
       this._userParamsController,
       this._addressObtainer,
+      this._offShopsManager,
       this._shop,
-      this._updateCallback,
-      this.offShopsmanager) {
+      this._updateCallback) {
     _confirmedProductsModel =
         ConfirmedProductsModel(shopsManager, _shop, _updateCallback);
     _suggestedProductsModel = SuggestedProductsModel(
@@ -88,5 +87,10 @@ class ShopProductRangePageModel {
 
   void onProductVisibilityChange(Product product, bool visible) {
     _suggestedProductsModel.onProductVisibilityChange(product, visible);
+  }
+
+  Future<String?> obtainCountryOfShop() async {
+    final offShop = await _offShopsManager.findOffShopByName(_shop.name);
+    return offShop.maybeOk()?.country?.name;
   }
 }

--- a/test/ui/base/components/shop_card_test.dart
+++ b/test/ui/base/components/shop_card_test.dart
@@ -82,6 +82,8 @@ void main() {
     backend = MockBackend();
     GetIt.I.registerSingleton<Backend>(backend);
     offShopsManager = MockOffShopsManager();
+    when(offShopsManager.findOffShopByName(any))
+        .thenAnswer((_) async => Ok(null));
     GetIt.I.registerSingleton<OffShopsManager>(offShopsManager);
     final addressObtainer = MockAddressObtainer();
     when(addressObtainer.addressOfShop(any))

--- a/test/ui/base/page_state_plante_test.dart
+++ b/test/ui/base/page_state_plante_test.dart
@@ -24,7 +24,7 @@ void main() {
   });
 }
 
-class _PageForTesting extends StatefulWidget {
+class _PageForTesting extends PagePlante {
   static const NAME = 'PageForTesting';
   const _PageForTesting({Key? key}) : super(key: key);
 

--- a/test/ui/shop/shop_product_range_page_confirmed_products_test.dart
+++ b/test/ui/shop/shop_product_range_page_confirmed_products_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plante/base/result.dart';
 import 'package:plante/l10n/strings.dart';
@@ -41,7 +40,7 @@ void main() {
   testWidgets('product range reloading on product range updates',
       (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     shopsManager.clear_verifiedCalls();
     await tester.pumpAndSettle();
@@ -55,7 +54,7 @@ void main() {
 
   testWidgets('displayed product range', (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     final cards =
         find.byType(ProductCard).evaluate().map((e) => e.widget).toList();
@@ -81,7 +80,7 @@ void main() {
 
   testWidgets('click on a product', (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     expect(find.byType(DisplayProductPage), findsNothing);
     await tester.tap(find.text(products[0].name!));
@@ -91,7 +90,7 @@ void main() {
 
   testWidgets('vote for product presence', (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     final card = find.byType(ProductCard).evaluate().first.widget;
     final product = products[0];
@@ -119,7 +118,7 @@ void main() {
 
   testWidgets('vote against product presence', (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     final card = find.byType(ProductCard).evaluate().first.widget;
     final product = products[0];
@@ -176,7 +175,7 @@ void main() {
     shopsManager.setShopRange(aShop.osmUID, Ok(range));
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     final product0Center = tester.getCenter(find.text(products[0].name!));
     final product1Center = tester.getCenter(find.text(products[1].name!));
@@ -214,7 +213,7 @@ void main() {
     shopsManager.setShopRange(aShop.osmUID, Ok(range));
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     final product0Center = tester.getCenter(find.text(products[0].name!));
     final product1Center = tester.getCenter(find.text(products[1].name!));
@@ -253,7 +252,7 @@ void main() {
 
     // Create widget
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     // Initial order
     var product0Center = tester.getCenter(find.text(products[0].name!));
@@ -308,7 +307,7 @@ void main() {
 
   testWidgets('voting removes vote options', (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     // YES vote
 
@@ -382,7 +381,7 @@ void main() {
   testWidgets('cancelled voting does not remove vote options',
       (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     // YES vote
 

--- a/test/ui/shop/shop_product_range_page_suggested_products_test.dart
+++ b/test/ui/shop/shop_product_range_page_suggested_products_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plante/l10n/strings.dart';
 import 'package:plante/model/country.dart';
@@ -46,7 +45,7 @@ void main() {
   testWidgets('suggested products title offShop not found',
       (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     final title = context
         .strings.shop_product_range_page_suggested_products_country_unknown
@@ -63,7 +62,7 @@ void main() {
       (WidgetTester tester) async {
     offShopsManager.setOffShop(Country.fr, aShop.name);
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
     final title = context
         .strings.shop_product_range_page_suggested_products_country
         .replaceAll('<SHOP>', aShop.name)
@@ -75,7 +74,7 @@ void main() {
       (WidgetTester tester) async {
     offShopsManager.setOffShop(null, aShop.name);
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
     final title = context
         .strings.shop_product_range_page_suggested_products_country_unknown
         .replaceAll('<SHOP>', aShop.name);
@@ -95,7 +94,7 @@ void main() {
     commons.setConfirmedProducts(commons.confirmedProducts);
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     final title = context
         .strings.shop_product_range_page_suggested_products_country_unknown
@@ -110,7 +109,7 @@ void main() {
     commons.setSuggestedProducts([suggestedProducts.first]);
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     final confirmedProductCenter =
         tester.getCenter(find.text(confirmedProducts.first.name!));
@@ -127,7 +126,7 @@ void main() {
     commons.setSuggestedProducts(suggestedProducts);
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     expect(find.text(suggestedProducts[0].name!), findsNothing);
     expect(find.text(suggestedProducts[1].name!), findsOneWidget);
@@ -152,7 +151,7 @@ void main() {
     commons.setSuggestedProducts(suggestedProducts);
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     final scrollDown = () async {
       // NOTE: we pause products retrieval before the scroll down

--- a/test/ui/shop/shop_product_range_page_test.dart
+++ b/test/ui/shop/shop_product_range_page_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plante/base/result.dart';
 import 'package:plante/l10n/strings.dart';
@@ -49,7 +48,7 @@ void main() {
 
   testWidgets('shop name in title', (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
     expect(find.text(aShop.name), findsOneWidget);
   });
 
@@ -61,7 +60,7 @@ void main() {
 
     final widget = ShopProductRangePage.createForTesting(aShop,
         addressLoadFinishCallback: addressCompleter.complete);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
     await tester.awaitableFutureFrom(addressCompleter.future);
 
     final expectedStr = AddressWidget.addressString(address, false, context)!;
@@ -70,7 +69,7 @@ void main() {
 
   testWidgets('close screen button', (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     expect(find.byType(ShopProductRangePage), findsOneWidget);
     await tester.tap(find.byKey(const Key('close_button')));
@@ -80,7 +79,7 @@ void main() {
 
   testWidgets('add product behaviour', (WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     expect(find.byType(BarcodeScanPage), findsNothing);
     await tester
@@ -98,7 +97,7 @@ void main() {
     commons.setSuggestedProducts(const []);
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     // No products title
     expect(
@@ -117,7 +116,7 @@ void main() {
         aShop.osmUID, Err(ShopsManagerError.NETWORK_ERROR));
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     // Network error
     expect(find.text(context.strings.global_network_error), findsOneWidget);
@@ -145,7 +144,7 @@ void main() {
     shopsManager.setShopRange(aShop.osmUID, Err(ShopsManagerError.OTHER));
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     // An error
     expect(
@@ -162,7 +161,7 @@ void main() {
   Future<void> testProductUpdateAfterClick(
       Product product, WidgetTester tester) async {
     final widget = ShopProductRangePage.createForTesting(aShop);
-    final context = await tester.superPump(ProviderScope(child: widget));
+    final context = await tester.superPump(widget);
 
     var card = find.byType(ProductCard).evaluate().first.widget;
     // Verify the proper product
@@ -251,7 +250,7 @@ void main() {
     commons.setSuggestedProducts([theProduct, otherSuggestedProduct]);
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     expect(find.text(theProduct.name!), findsNWidgets(1));
     expect(find.text(otherSuggestedProduct.name!), findsNWidgets(1));
@@ -293,7 +292,7 @@ void main() {
     await userParamsController.setUserParams(veganUser);
 
     final widget = ShopProductRangePage.createForTesting(aShop);
-    await tester.superPump(ProviderScope(child: widget));
+    await tester.superPump(widget);
 
     expect(find.text(products[0].name!), findsNothing);
     expect(find.text(products[1].name!), findsOneWidget);

--- a/test/widget_tester_extension.dart
+++ b/test/widget_tester_extension.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 extension WidgetTesterExtension on WidgetTester {
@@ -15,7 +16,8 @@ extension WidgetTesterExtension on WidgetTester {
 
     final Widget widgetWrapper = MediaQuery(
         data: const MediaQueryData(),
-        child: MaterialApp(
+        child: ProviderScope(
+            child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           home: Builder(
             builder: (BuildContext context) {
@@ -26,7 +28,7 @@ extension WidgetTesterExtension on WidgetTester {
           navigatorObservers: [
             if (navigatorObserver != null) navigatorObserver
           ],
-        ));
+        )));
 
     await pumpWidget(widgetWrapper, duration, phase);
     await pumpAndSettle();


### PR DESCRIPTION
Please ignore most of the `... page.dart` files - they're changed only because `page_state_plante.dart` is changed.

I played a bit with Riverpod and the changes you've made with it, and came up with a couple suggestions for how we probably should use it.
I don't know if you will agree with some/all suggestions - this is the first time I use Riverpod and I barely read its documentation.

Main changes:
1. Riverpod is not just a state-management tool, but it also provides Dependency-Injection functionality, and uses its DI in some cases.
    That's why you've added `offShopsProvider` to `shop_product_range_page.dart` - it's a provider of a singleton for Riverpod.
    Here's how the declaration looks:
    ```(dart)
    final offShopsProvider =
      Provider<OffShopsManager>((ref) => GetIt.I.get<OffShopsManager>());
    ```
    When I though about this declaration, it started to look a bit strange - we already use `GetIt` for DI, but now there's another DI-code and the `offShopsProvider` object is just a bridge between these 2 DI frameworks... I don't think it's a good idea to have 2 DI, so I removed the `offShopsProvider` object.
2. Now the Shop Range Page uses country name with kind of value-mechanics with the field `final _countryNameProvider = StateProvider<String?>((ref) => null);`.
    The field can be updated with `ref.read(_countryNameProvider.state).state = ...`, almost like if it was just `String? _countryName`.
    I think it makes work with the field more intuitive, because when (at least) I think: "So, the country name will take some time to load, so at first there will be `null`, but at some point there will be a String value", I then imagine a nullable field `String?`.
    Maybe at some point it would be a good idea to add a `setValue(RiverpodProvider<T>, T value)` and `readValue` functions to `PageStatePlante`. So that `ref.read(_countryNameProvider.state).state = ...` would become `setValue(_countryNameProvider, 'newValue')`.
3. `PagePlante` class is created and all pages are inherited from it. This change will allow all of the pages to directly use the Riverpod's `ref` object without Consumers. Right now we don't need it, but in the future we most likely will.
4. Moved logic of obtaining country code to `ShopProductRangePageModel` - I think we should try to leave only UI-related logic in the `Page` classes, and all work with "model" should be done in `Model` classes.
5. Moved `ProviderScope` in tests to the `superPump` function.